### PR TITLE
update references for CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-# CRDs Makefile - Enterprise Contract Policy CRDs
-# Extracted from enterprise-contract-controller repository
+# CRDs Makefile - Conforma CRDs
 
 ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/schema/export.go
+++ b/schema/export.go
@@ -42,7 +42,7 @@ Please ensure you've provided the following:
     The file will be titled schema.json
   * A repository for the Go source file containing the struct used in schema creation."
   * The path to the directory containing the Go source file which contains the struct used for schema creation.
-    Example: go run schema/export.go /tmp/enterprise-contract-controller github.com/enterprise-contract/enterprise-contract-controller ./api/v1alpha1/
+    Example: go run schema/export.go /tmp/conforma-crds github.com/conforma/crds ./api/v1alpha1/
 
 `)
 		os.Exit(1)


### PR DESCRIPTION
This commit updates references for CRDs from
`github.com/enterprise-contract/enterprise-contract-controller` to `github.com/conforma/crds`.

Additionally, removed unecessary comment in Makefile which referenced the same repository.

Ref: EC-1422