### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,61 @@
+---
+name: Release
+
+"on":
+  workflow_run:
+    workflows: [Checks]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  info:
+    name: Info
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.head_sha.outputs.head_sha }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
+
+    steps:
+      - name: Git Info
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_COBRA: 1
+        run: |
+          echo head_sha=$(gh api /repos/conforma/crds/git/matching-refs/heads/main --jq '.[0].object.sha') >> "$GITHUB_OUTPUT"
+
+  release:
+
+    permissions:
+      contents: write  # for Git to git tag push and release
+    name: Release
+    runs-on: ubuntu-latest
+    needs: info
+    if: ${{ (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha == needs.info.outputs.head_sha) || github.event.workflow_dispatch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+
+          echo "version=$(./hack/next-version.sh)" >> "$GITHUB_ENV"
+
+      - name: API Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        with:
+          name: API Release ${{env.version}}
+          tag_name: ${{env.version}}
+          generate_release_notes: true

--- a/hack/next-version.sh
+++ b/hack/next-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright The Conforma Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO: Add usage
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function debug() {
+    >&2 echo "DEBUG: ${1}"
+}
+
+# E.g. api/v0.1.33
+latest_version="$(git tag | sort -V -r | head -n 1)"
+debug "Latest version: ${latest_version}"
+
+# Handle case when no tags exist
+if [[ -z "${latest_version}" ]]; then
+    debug "No existing tags found, starting with default version"
+    next_version="api/v0.1.0"
+else
+    latest_patch_version="$(echo -n ${latest_version} | cut -d. -f3)"
+    debug "Latest patch version: ${latest_patch_version}"
+
+    version_prefix="$(echo -n ${latest_version} | cut -d. -f1-2)"
+    debug "Version prefix: ${version_prefix}"
+
+    next_patch_version="$((${latest_patch_version}+1))"
+    debug "Next patch version: ${next_patch_version}"
+
+    next_version="${version_prefix}.${next_patch_version}"
+fi
+debug "Next version is: ${next_version}"
+
+echo -n "${next_version}"

--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Updates a local clone of redhat-appstudio/infra-deployments to use the latest
+# packages produced by this repository.
+# Usage:
+#   update-infra-deployments.sh <PATH_TO_INFRA_DEPLOYMENTS> [<REVISION>]
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+REVISION="${2-$(git rev-parse HEAD)}"
+
+TARGET_DIR="${1}"
+cd "${TARGET_DIR}" || exit 1
+
+echo "Updating infra-deployments to revision ${REVISION}..."
+sed -i \
+  -e 's|\(https://github.com/conforma/crds/.*?ref=\)\(.*\)|\1'${REVISION}'|' \
+  -e 's|\(https://raw.githubusercontent.com/conforma/crds/\)\([[:alnum:]]*\)\(.*\)|\1'${REVISION}'\3|' \
+  -e 's/\(newTag: \).*/\1'${REVISION}'/' \
+  components/enterprise-contract/kustomization.yaml
+echo 'infra-deployments updated successfully'


### PR DESCRIPTION
This commit adds a github release workflow which was used in the `github.com/enterprise-contract/enterprise-contract-controller` repository which this repository is replacing.

This commit updates the `next-version.sh` script to handle the situation where there is no existing release, initializing the first release as `api/v0.1.0`.

Ref: EC-1422