### PR TITLE
update reference to crd xref

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,7 +34,7 @@ include::example$spec-example.json[]
 ----
 
 Consult the
-xref:reference.adoc#k8s-api-github-com-enterprise-contract-enterprise-contract-controller-api-v1alpha1-enterprisecontractpolicyspec[the
+xref:reference.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicyspec[the
 EnterpriseContractPolicySpec reference] documentation for details on the
 structure of this document.
 


### PR DESCRIPTION
This commit updates the xref for the EnterpriseContractPolicySpec to reflect the migration from
`github.com/enterprise-contract/enterprise-contract-controller` to `github.com/conforma/crds`.