### PR TITLE
fix reference.adoc xref

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,2 @@
 * xref:index.adoc[About Conforma Configuration]
-* xref:reference.adoc[Reference]
+* xref:cli:ROOT:reference.adoc[Reference]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,7 +34,7 @@ include::example$spec-example.json[]
 ----
 
 Consult the
-xref:reference.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicyspec[the
+xref:cli:ROOT:reference.adoc#k8s-api-github-com-conforma-crds-api-v1alpha1-enterprisecontractpolicyspec[the
 EnterpriseContractPolicySpec reference] documentation for details on the
 structure of this document.
 


### PR DESCRIPTION
This commit updates the `reference.adoc` xref from the `ecc` module to the `cli` module.

Ref: EC-1422