### PR TITLE
feat: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,12 +10,14 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   Checks:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,7 +42,7 @@ jobs:
         run: make test
 
       - name: Upload API coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           flags: unit-tests
@@ -50,7 +50,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload schema coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           flags: unit-tests

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   Checks:
@@ -40,7 +41,21 @@ jobs:
       - name: Test
         run: make test
 
-# Coverage reporting removed for now - can be added later if needed
+      - name: Upload API coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: ./api_cover.out
+          fail_ci_if_error: false
+
+      - name: Upload schema coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: ./schema_cover.out
+          fail_ci_if_error: false
 
       # If enterprisecontractpolicy_types.go is updated without a corresponding change to the crd
       # an uncommitted change can show.


### PR DESCRIPTION
## Summary
- Wire up `codecov-action` to upload unit test coverage after `make test`
- Uses OIDC authentication (no token secret needed)
- Uploads both `api_cover.out` and `schema_cover.out` with `unit-tests` flag
- Coverage runs on both push to main and PRs

## Test plan
- [ ] CI workflow passes with new codecov upload steps
- [ ] Coverage data appears at https://app.codecov.io/gh/conforma/crds
- [ ] `unit-tests` flag visible in Codecov Flags tab

Ref: COVERPORT-206